### PR TITLE
State to be in the tree

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 # Checklist:
 
-- [ ] Performance did not regress. If it did, then it is explained above in the Decisions section.
+- [ ] Performance did not regress. If it did, then it is explained below in the Decisions section.
 - [ ] Nodes still change their colors when their values get updated.
 - [ ] Comments are only added if they are really necessary. Descriptive function and variable names are preferred.
 - [ ] Build warnings eliminated.
@@ -19,12 +19,5 @@
   <summary>iPhone Screenshots/Recordings</summary>
 
   <!-- place your iPhone screenshots here -->
-
-</details>
-
-<details>
-  <summary>iPad Screenshots/Recordings</summary>
-
-  <!-- place your iPad screenshots here -->
 
 </details>

--- a/SwiftUIViewTree/DemoApp/ContentView.swift
+++ b/SwiftUIViewTree/DemoApp/ContentView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 //                .font(.largeTitle)
 //                .bold()
 //        }
-//        .renderViewTree() // <--
+//        .renderViewTree(of: self) // <--
 //    }
 //}
 

--- a/SwiftUIViewTree/DemoApp/ContentView.swift
+++ b/SwiftUIViewTree/DemoApp/ContentView.swift
@@ -27,7 +27,7 @@ struct ContentView: View {
         }
 //        .printViewTree()
 //        .renderViewTree(maxDepth: 3)
-        .renderViewTree()
+        .renderViewTree(of: self)
     }
 }
 

--- a/SwiftUIViewTree/Internal/DataStructures/TreeDataStructure/Tree.swift
+++ b/SwiftUIViewTree/Internal/DataStructures/TreeDataStructure/Tree.swift
@@ -3,7 +3,7 @@ import Observation
 @Observable
 final class Tree: Equatable {
     var parentNode: TreeNode
-    var children: [Tree] // TODO: parents with only one child should be merged with their children
+    var children: [Tree]
 
     init(
         node: TreeNode,

--- a/SwiftUIViewTree/Internal/DataStructures/TreeDataStructure/Tree.swift
+++ b/SwiftUIViewTree/Internal/DataStructures/TreeDataStructure/Tree.swift
@@ -14,6 +14,7 @@ final class Tree: Equatable {
     }
 
     static func == (lhs: Tree, rhs: Tree) -> Bool {
-        lhs.parentNode == rhs.parentNode
+        lhs.parentNode == rhs.parentNode &&
+        lhs.children == rhs.children
     }
 }

--- a/SwiftUIViewTree/Internal/DataStructures/TreeDataStructure/Tree.swift
+++ b/SwiftUIViewTree/Internal/DataStructures/TreeDataStructure/Tree.swift
@@ -1,7 +1,7 @@
 import Observation
 
 @Observable
-final class Tree: /*CustomStringConvertible,*/ Equatable {
+final class Tree: Equatable {
     var parentNode: TreeNode
     var children: [Tree] // TODO: parents with only one child should be merged with their children
 

--- a/SwiftUIViewTree/Internal/Domain/TreeContainer.swift
+++ b/SwiftUIViewTree/Internal/Domain/TreeContainer.swift
@@ -22,19 +22,55 @@ final class TreeContainer {
                     }
             }
 
+            let originalViewMirror = Mirror(reflecting: originalView)
+
+            let originalViewRootNode = TreeNode(
+                type: "\(type(of: originalView))",
+                label: "originalView",
+                value: "\(originalView)",
+                displayStyle: "\(String(describing: originalViewMirror.displayStyle))",
+                subjectType: "\(originalViewMirror.subjectType)",
+                superclassMirror: String(describing: originalViewMirror.superclassMirror),
+                mirrorDescription: originalViewMirror.description,
+                childIndex: 0,
+                isParent: originalViewMirror.children.count > 0
+            )
+
             let newTree = Tree(
                 node: .rootNode
             )
-            newTree.children = convertToTreesRecursively(
+
+            newTree.children = [
+                Tree(node: originalViewRootNode)
+            ]
+
+            newTree.children[0].children = convertToTreesRecursively(
                 mirror: Mirror(reflecting: originalView),
                 source: originalView,
                 maxDepth: maxDepth
             )
-            newTree.children.append(contentsOf: convertToTreesRecursively(
+
+            let modifiedViewMirror = Mirror(reflecting: modifiedView)
+
+            let modifiedViewRootNode = TreeNode(
+                type: "\(type(of: modifiedView))",
+                label: "modifiedView",
+                value: "\(modifiedView)",
+                displayStyle: "\(String(describing: modifiedViewMirror.displayStyle))",
+                subjectType: "\(modifiedViewMirror.subjectType)",
+                superclassMirror: String(describing: modifiedViewMirror.superclassMirror),
+                mirrorDescription: modifiedViewMirror.description,
+                childIndex: 0,
+                isParent: modifiedViewMirror.children.count > 0
+            )
+
+            newTree.children.append(Tree(node: modifiedViewRootNode))
+
+            newTree.children[1].children = convertToTreesRecursively(
                 mirror: Mirror(reflecting: modifiedView),
                 source: modifiedView,
                 maxDepth: maxDepth
-            ))
+            )
 
             // (Un)comment this to simulate delay in computing the tree
             try? await Task.sleep(for: .seconds(1))

--- a/SwiftUIViewTree/Internal/Domain/TreeContainer.swift
+++ b/SwiftUIViewTree/Internal/Domain/TreeContainer.swift
@@ -61,24 +61,24 @@ private extension TreeContainer {
         )
 
         let originalViewRootNode = getRootTreeNode(of: originalView, as: .originalView)
-
-        newTree.children.append(Tree(node: originalViewRootNode))
-
-        newTree.children[0].children = convertToTreesRecursively(
+        let originalViewTree = Tree(node: originalViewRootNode)
+        originalViewTree.children = convertToTreesRecursively(
             mirror: Mirror(reflecting: originalView),
             source: originalView,
             maxDepth: maxDepth
         )
 
+        newTree.children.append(originalViewTree)
+
         let modifiedViewRootNode = getRootTreeNode(of: modifiedView, as: .modifiedView)
-
-        newTree.children.append(Tree(node: modifiedViewRootNode))
-
-        newTree.children[1].children = convertToTreesRecursively(
+        let modifiedViewTree = Tree(node: modifiedViewRootNode)
+        modifiedViewTree.children = convertToTreesRecursively(
             mirror: Mirror(reflecting: modifiedView),
             source: modifiedView,
             maxDepth: maxDepth
         )
+
+        newTree.children.append(modifiedViewTree)
 
         return newTree
     }

--- a/SwiftUIViewTree/Internal/Domain/TreeContainer.swift
+++ b/SwiftUIViewTree/Internal/Domain/TreeContainer.swift
@@ -60,25 +60,19 @@ private extension TreeContainer {
             node: .rootNode
         )
 
-        let originalViewRootNode = getRootTreeNode(of: originalView, as: .originalView)
-        let originalViewTree = Tree(node: originalViewRootNode)
-        originalViewTree.children = convertToTreesRecursively(
-            mirror: Mirror(reflecting: originalView),
-            source: originalView,
+        let originalViewRootTree = getRootTree(
+            from: originalView,
+            as: .originalView,
             maxDepth: maxDepth
         )
+        newTree.children.append(originalViewRootTree)
 
-        newTree.children.append(originalViewTree)
-
-        let modifiedViewRootNode = getRootTreeNode(of: modifiedView, as: .modifiedView)
-        let modifiedViewTree = Tree(node: modifiedViewRootNode)
-        modifiedViewTree.children = convertToTreesRecursively(
-            mirror: Mirror(reflecting: modifiedView),
-            source: modifiedView,
+        let modifiedViewRootTree = getRootTree(
+            from: modifiedView,
+            as: .modifiedView,
             maxDepth: maxDepth
         )
-
-        newTree.children.append(modifiedViewTree)
+        newTree.children.append(modifiedViewRootTree)
 
         return newTree
     }
@@ -122,6 +116,17 @@ private extension TreeContainer {
             return childTree
         }
         return result
+    }
+
+    func getRootTree(from rootView: any View, as rootNodeType: RootNodeType, maxDepth: Int) -> Tree {
+        let rootNode = getRootTreeNode(of: rootView, as: rootNodeType)
+        let rootViewTree = Tree(node: rootNode)
+        rootViewTree.children = convertToTreesRecursively(
+            mirror: Mirror(reflecting: rootView),
+            source: rootView,
+            maxDepth: maxDepth
+        )
+        return rootViewTree
     }
 
     func getRootTreeNode(of view: any View, as rootNodeType: RootNodeType) -> TreeNode {

--- a/SwiftUIViewTree/Internal/Domain/TreeContainer.swift
+++ b/SwiftUIViewTree/Internal/Domain/TreeContainer.swift
@@ -91,10 +91,6 @@ private extension TreeContainer {
             return []
         }
 
-        //        print()
-        //        print(source)
-        //        print()
-
         let result = mirror.children.enumerated().map { (index, child) in
             let childMirror = Mirror(reflecting: child.value)
 

--- a/SwiftUIViewTree/Internal/Domain/TreeContainer.swift
+++ b/SwiftUIViewTree/Internal/Domain/TreeContainer.swift
@@ -22,7 +22,11 @@ final class TreeContainer {
                     }
             }
 
-            let newTree = getTreeFrom(originalView: originalView, modifiedView: modifiedView, maxDepth: maxDepth)
+            let newTree = getTreeFrom(
+                originalView: originalView,
+                modifiedView: modifiedView,
+                maxDepth: maxDepth
+            )
 
             // (Un)comment this to simulate delay in computing the tree
             try? await Task.sleep(for: .seconds(1))

--- a/SwiftUIViewTree/Public/View+Extensions.swift
+++ b/SwiftUIViewTree/Public/View+Extensions.swift
@@ -15,6 +15,7 @@ public extension View {
     //        return self
     //    }
 
+    //TODO: documentation
     func renderViewTree(of originalView: any View, maxDepth: Int = .max) -> some View {
         TreeContainer.shared.computeViewTree(
             maxDepth: maxDepth,

--- a/SwiftUIViewTree/Public/View+Extensions.swift
+++ b/SwiftUIViewTree/Public/View+Extensions.swift
@@ -2,23 +2,24 @@ import SwiftUI
 
 public extension View {
     /// Left behind. Working out renderViewTree for now.
-//    func printViewTree(maxDepth: Int = .max) -> some View { //TODO: to test
-//        let tree = Tree(
-//            node: .rootNode
-//        )
-//        tree.children = TreeContainer.shared.convertToTreesRecursively(
-//            mirror: Mirror(reflecting: self),
-//            maxDepth: maxDepth
-//        )
-//
-//        print(tree)
-//        return self
-//    }
+    //    func printViewTree(maxDepth: Int = .max) -> some View { //TODO: to test
+    //        let tree = Tree(
+    //            node: .rootNode
+    //        )
+    //        tree.children = TreeContainer.shared.convertToTreesRecursively(
+    //            mirror: Mirror(reflecting: self),
+    //            maxDepth: maxDepth
+    //        )
+    //
+    //        print(tree)
+    //        return self
+    //    }
 
-    func renderViewTree(maxDepth: Int = .max) -> some View {
+    func renderViewTree(of originalView: any View, maxDepth: Int = .max) -> some View {
         TreeContainer.shared.computeViewTree(
             maxDepth: maxDepth,
-            source: self
+            originalView: originalView,
+            modifiedView: self
         )
         return modifier(RenderViewTreeModifier())
     }


### PR DESCRIPTION
# Checklist:

- [-] Performance did not regress. If it did, then it is explained below in the Decisions section.
- [x] Nodes still change their colors when their values get updated.
- [x] Comments are only added if they are really necessary. Descriptive function and variable names are preferred.
- [x] Build warnings eliminated.

# Description
"@State" and other view properties weren't visible in the view tree. This PR shows them as well

## Decisions
Realizing that the self passed into a view modifier is not the same self that is used inside the view modifier. Thus I had to pass in `self` to the `renderViewTree` (originalView), while still using the `self` inside the tree calculation (modifiedView).

# Screenshot/Demos

<details>
  <summary>iPhone Screenshots/Recordings</summary>

<img width="929" height="522" alt="image" src="https://github.com/user-attachments/assets/a976e37f-8740-48c0-8d7d-819de990448c" />

<img width="928" height="520" alt="image" src="https://github.com/user-attachments/assets/5bda4495-1c1e-4b1a-b4f7-7e1e75c8fb0b" />

<img width="935" height="527" alt="image" src="https://github.com/user-attachments/assets/1cc333ea-050d-423a-a379-d4d4087a3823" />

</details>

<details>
  <summary>iPad Screenshots/Recordings</summary>

  <!-- place your iPad screenshots here -->

</details>
