### PR TITLE
Regression clearup

### DIFF
--- a/SwiftUIViewTree/Sources/SwiftUIViewTree/Internal/DataStructures/LinkedColorList.swift
+++ b/SwiftUIViewTree/Sources/SwiftUIViewTree/Internal/DataStructures/LinkedColorList.swift
@@ -4,13 +4,13 @@ import SwiftUI
 struct LinkedColorList {
     let colors: [Color] = [
         UIConstants.Color.initialNodeBackground,
-        .red.opacity(0.8),
-        .yellow.opacity(0.8),
-        .green.opacity(0.8),
-        .orange.opacity(0.8),
-        .pink.opacity(0.8),
-        .mint.opacity(0.8),
-        .indigo.opacity(0.8)
+        .red,
+        .yellow,
+        .green,
+        .orange,
+        .pink,
+        .mint,
+        .indigo,
     ]
     private var currentIndex = 0
 

--- a/SwiftUIViewTree/Sources/SwiftUIViewTree/Internal/DataStructures/Tree/TreeNode.swift
+++ b/SwiftUIViewTree/Sources/SwiftUIViewTree/Internal/DataStructures/Tree/TreeNode.swift
@@ -62,6 +62,11 @@ final class TreeNode: Sendable {
             try TreeNodeRegistry.shared.registerNode(serialNumber: serialNumber, value: value)
         } catch {
             if value != oldValue {
+                ViewTreeLogger.shared.logChangesOf(
+                    node: self,
+                    previousNodeValue: oldValue
+                )
+
                 TreeNodeRegistry.shared.registerChangedNode(self)
             }
         }

--- a/SwiftUIViewTree/Sources/SwiftUIViewTree/Internal/UI/Constants/UIConstants.swift
+++ b/SwiftUIViewTree/Sources/SwiftUIViewTree/Internal/UI/Constants/UIConstants.swift
@@ -9,7 +9,7 @@ enum UIConstants {
     }
 
     enum Color {
-        static let collapsedNodeBackground = SwiftUI.Color.gray.opacity(0.8)
-        static let initialNodeBackground = SwiftUI.Color.purple.opacity(0.8)
+        static let collapsedNodeBackground = SwiftUI.Color.gray
+        static let initialNodeBackground = SwiftUI.Color.purple
     }
 }

--- a/SwiftUIViewTree/Sources/SwiftUIViewTree/Internal/UI/Gestures/DragToScrollGesture.swift
+++ b/SwiftUIViewTree/Sources/SwiftUIViewTree/Internal/UI/Gestures/DragToScrollGesture.swift
@@ -23,7 +23,7 @@ struct DragToScrollGesture: Gesture {
             }
             .onEnded { value in
                 withAnimation {
-                    offset = getClampedNewOffset(from: value)
+                    offset = getNewOffset(from: value)
                 }
             }
     }
@@ -35,19 +35,6 @@ private extension DragToScrollGesture {
         // Scale is taken as a factor to make the dragging feel more natural when zoomed in, i.e. less sensitive.
         newOffset.width += (value.translation.width / 2) / max(self.scale, 1)
         newOffset.height += (value.translation.height / 2) / max(self.scale, 1)
-        return newOffset
-    }
-
-    func getClampedNewOffset(from value: DragGesture.Value) -> CGSize {
-        let newOffset = getNewOffset(from: value)
-        let clampedNewOffset = clampNewOffset(newOffset)
-        return clampedNewOffset
-    }
-
-    func clampNewOffset(_ newOffset: CGSize) -> CGSize {
-        var newOffset = newOffset
-        newOffset.width = min(max(newOffset.width, -horizontalMaxScale), horizontalMaxScale)
-        newOffset.height = min(max(newOffset.height, -verticalMaxScale), verticalMaxScale)
         return newOffset
     }
 }

--- a/SwiftUIViewTree/Sources/SwiftUIViewTree/Internal/UI/Gestures/DragToScrollGesture.swift
+++ b/SwiftUIViewTree/Sources/SwiftUIViewTree/Internal/UI/Gestures/DragToScrollGesture.swift
@@ -30,6 +30,7 @@ struct DragToScrollGesture: Gesture {
 }
 
 private extension DragToScrollGesture {
+    //TODO: there used to be some clamping here but it was fragile. got deleted in commit: fae1d7469c45fbfc4ebb7eff808abee453b00e5f
     func getNewOffset(from value: DragGesture.Value) -> CGSize {
         var newOffset = self.offset
         // Scale is taken as a factor to make the dragging feel more natural when zoomed in, i.e. less sensitive.

--- a/SwiftUIViewTree/Sources/SwiftUIViewTree/Internal/UI/Gestures/DragToScrollGesture.swift
+++ b/SwiftUIViewTree/Sources/SwiftUIViewTree/Internal/UI/Gestures/DragToScrollGesture.swift
@@ -4,16 +4,6 @@ struct DragToScrollGesture: Gesture {
     @Binding var offset: CGSize
     let scale: CGFloat
 
-    //TODO: probably these values (2000, 1000) won't be good for all use cases
-    /// The maximum horizontal offset allowed at the current scale
-    private var horizontalMaxScale: CGFloat {
-        2000 * ((scale - floor(scale)) + 1)
-    }
-    /// The maximum vertical offset allowed at the current scale
-    private var verticalMaxScale: CGFloat {
-        1000 * ((scale - floor(scale)) + 1)
-    }
-
     var body: some Gesture {
         DragGesture()
             .onChanged { value in

--- a/SwiftUIViewTree/Sources/SwiftUIViewTree/Internal/UI/Views/ScrollableZoomableTreeView.swift
+++ b/SwiftUIViewTree/Sources/SwiftUIViewTree/Internal/UI/Views/ScrollableZoomableTreeView.swift
@@ -65,6 +65,9 @@ struct ScrollableZoomableTreeView: View {
                     if isPerformanceLoggingEnabled {
                         print("ScrollableZoomableTreeView Appeared: \(Date())")
                     }
+
+                    //TODO: without this below tapping on nodes isn't recognized before some zooming or scrolling, only after
+                    self.offset = .init(width: 1, height: 1)
                 }
         }
     }

--- a/SwiftUIViewTree/Tests/SwiftUIViewTreeTests/Internal/DataStructures/Tree/TreeNodeTests.swift
+++ b/SwiftUIViewTree/Tests/SwiftUIViewTreeTests/Internal/DataStructures/Tree/TreeNodeTests.swift
@@ -19,7 +19,7 @@ struct TreeNodeTests {
             #expect(registeredValue == node.value)
         }
 
-        @Test
+        @Test(.viewTree(viewTreeLogger: SpyViewTreeLogger()))
         func getsRegistered_Twice_ThereIs_NO_ValueChange() {
             //GIVEN
             let node1 = TreeNode.createMock(
@@ -41,9 +41,14 @@ struct TreeNodeTests {
 
             //THEN
             #expect(TreeNodeRegistry.shared.allChangedNodes.contains(where: { $0.serialNumber == node1.serialNumber }) == false)
+            guard let spyViewTreeLogger = ViewTreeLogger.shared as? SpyViewTreeLogger else {
+                Issue.record("ViewTreeLogger is not spy: \(ViewTreeLogger.shared)")
+                return
+            }
+            #expect(spyViewTreeLogger.hasBeenCalled == false)
         }
 
-        @Test
+        @Test(.viewTree(viewTreeLogger: SpyViewTreeLogger()))
         func getsRegistered_Twice_There_IS_ValueChange() {
             //GIVEN
             let value1 = "value1"
@@ -68,6 +73,12 @@ struct TreeNodeTests {
 
             //THEN
             #expect(TreeNodeRegistry.shared.allChangedNodes.contains(where: { $0.serialNumber == node1.serialNumber }) == true)
+            guard let spyViewTreeLogger = ViewTreeLogger.shared as? SpyViewTreeLogger else {
+                Issue.record("ViewTreeLogger is not spy: \(ViewTreeLogger.shared)")
+                return
+            }
+            #expect(spyViewTreeLogger.hasBeenCalled == true)
+
         }
     }
 


### PR DESCRIPTION
# Checklist:

- [x] Performance did not regress. If it did, then it is explained below in the Decisions section.
- [x] Nodes still change their colors when their values get updated.
- [x] Parent nodes (except Root Node) are collapsible. Child nodes are not.
- [x] Comments are only added if they are really necessary. Descriptive function and variable names are preferred.
- [x] Build warnings eliminated.

# Description
There were some regression due to the previous PRs that are fixed here.